### PR TITLE
OAI-9:  Remove marcx subfield 241u if BKM set not allowed

### DIFF
--- a/formatter-js/src/main/resources/javascript/MarcXchangeToOaiMarcX.use.js
+++ b/formatter-js/src/main/resources/javascript/MarcXchangeToOaiMarcX.use.js
@@ -157,6 +157,38 @@ var MarcXchangeToOaiMarcX = function() {
     }
 
     /**
+     * Function that removes subfield 241u in the marc record if it exists.
+     * Search US#OAI-9
+     * @syntax MarcXchangeToOaiMarcX.removeSubfield241u( marcRecord )
+     * @param {Record} marcRecord the marc record to check for subfield 241u
+     * @return {Record} a new record without subfield 241u
+     * @type {function}
+     * @function
+     * @name MarcXchangeToOaiMarcX.removeSubfield241u
+     */
+    function removeSubfield241u( marcRecord ) {
+
+        Log.trace( "Entering MarcXchangeToOaiMarcX.removeSubfield241u" );
+
+        var modifiedRecord = marcRecord.clone();
+
+        modifiedRecord.eachField( /./, function( field ) {
+            if( field.name === "241") {
+                var subfieldMatcher = {
+                    matchSubField: function (field, subfield) {
+                        return (subfield.name === 'u');
+                    }
+                };
+                field.removeWithMatcher(subfieldMatcher);
+            }
+        } );
+
+        Log.trace( "Leaving MarcXchangeToOaiMarcX.removeSubfield241u" );
+
+        return modifiedRecord;
+    }
+
+    /**
      * Function that removes field 665 from the marc record if it exists.
      * This is a function for temporary use - until field 665 is an official
      * danMARC2 field. Search US #2373.
@@ -176,7 +208,6 @@ var MarcXchangeToOaiMarcX = function() {
 
         var fieldMatcher = {
             matchField: function( modifiedRecord, field ) {
-                //fields starting with a letter should be removed
                 return ( "665" === field.name );
             }
         };
@@ -233,6 +264,7 @@ var MarcXchangeToOaiMarcX = function() {
         removeBkmFields: removeBkmFields,
         removeLocalFieldsIfAny: removeLocalFieldsIfAny,
         removeLocalSubfieldsIfAny: removeLocalSubfieldsIfAny,
+        removeSubfield241u: removeSubfield241u,
         removeField665: removeField665,
         getRecordType: getRecordType
     }

--- a/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
+++ b/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
@@ -991,13 +991,10 @@ UnitTest.addFixture( "OaiFormatter.getAllowedFormats", function() {
 
 } );
 
-// TODO: starting with unit tests
+
 UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, subfield 241u)", function() {
 
     var format = 'marcx'; // applies to all tests in this fixture
-
-    // Part 1: Include 241u when allowed sets contains BKM
-    var allowedSets = [ "BKM", "NAT" ];
 
     var recordString =
        '<marcx:record format="danMARC2" type="Bibliographic" xmlns:marcx="info:lc/xmlns/marcxchange-v1">' +
@@ -1061,6 +1058,9 @@ UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, subfield 241u)",
         }
     ];
 
+    // Part 1: Include 241u when allowed sets contains BKM
+    var allowedSets = [ "BKM", "NAT" ];
+
     var expected =
         '<marcx:collection xmlns:marcx="info:lc/xmlns/marcxchange-v1">' +
             '<marcx:record format="danMARC2" type="Bibliographic">' +
@@ -1112,16 +1112,16 @@ UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, subfield 241u)",
                 '</marcx:datafield>' +
                 '<marcx:datafield ind1="0" ind2="0" tag="241">' +
                     '<marcx:subfield code="a">Romancero gitano</marcx:subfield>' +
-                    '<marcx:subfield code="u">1928</marcx:subfield>' + // 241u
+                    '<marcx:subfield code="u">1928</marcx:subfield>' + // subfield 241u
                 '</marcx:datafield>' +
             '</marcx:record>' +
         '</marcx:collection>';
 
     var actual = OaiFormatter.formatRecords( records, format, allowedSets );
-    var testName = "Format single record to marcxchange + bkm allowed set + show subfield 241 *u";
+    var testName = "Format single record to marcxchange + bkm allowed set + show subfield 241u";
     Assert.equalXml( testName, actual, expected );
 
-    // excluding 241u when allowed set is only NAT
+    // Part 2: Excluding 241u when allowed set is only NAT
     allowedSets = ["NAT"];
 
     expected =
@@ -1181,7 +1181,7 @@ UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, subfield 241u)",
         '</marcx:collection>';
 
     actual = OaiFormatter.formatRecords( records, format, allowedSets );
-    testName = "Format single record to marcxchange + bkm not allowed set + hide subfield 241 *u";
+    testName = "Format single record to marcxchange + bkm not allowed set + hide subfield 241u";
     Assert.equalXml( testName, actual, expected );
 
 });

--- a/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
+++ b/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
@@ -995,6 +995,8 @@ UnitTest.addFixture( "OaiFormatter.getAllowedFormats", function() {
 UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, subfield 241u)", function() {
 
     var format = 'marcx'; // applies to all tests in this fixture
+
+    // Part 1: Include 241u when allowed sets contains BKM
     var allowedSets = [ "BKM", "NAT" ];
 
     var recordString =
@@ -1059,7 +1061,6 @@ UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, subfield 241u)",
         }
     ];
 
-    // include 241u
     var expected =
         '<marcx:collection xmlns:marcx="info:lc/xmlns/marcxchange-v1">' +
             '<marcx:record format="danMARC2" type="Bibliographic">' +
@@ -1111,15 +1112,76 @@ UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, subfield 241u)",
                 '</marcx:datafield>' +
                 '<marcx:datafield ind1="0" ind2="0" tag="241">' +
                     '<marcx:subfield code="a">Romancero gitano</marcx:subfield>' +
-                    '<marcx:subfield code="u">1928</marcx:subfield>' +
+                    '<marcx:subfield code="u">1928</marcx:subfield>' + // 241u
                 '</marcx:datafield>' +
             '</marcx:record>' +
         '</marcx:collection>';
 
     var actual = OaiFormatter.formatRecords( records, format, allowedSets );
-
     var testName = "Format single record to marcxchange + bkm allowed set + show subfield 241 *u";
+    Assert.equalXml( testName, actual, expected );
 
+    // excluding 241u when allowed set is only NAT
+    allowedSets = ["NAT"];
+
+    expected =
+        '<marcx:collection xmlns:marcx="info:lc/xmlns/marcxchange-v1">' +
+        '<marcx:record format="danMARC2" type="Bibliographic">' +
+        '<marcx:leader>00000name 22000000  4500</marcx:leader>' +
+        '<marcx:datafield ind1="0" ind2="0" tag="001">' +
+        '<marcx:subfield code="a">38240803</marcx:subfield>' +
+        '<marcx:subfield code="b">870970</marcx:subfield>' +
+        '<marcx:subfield code="c">20210216122929</marcx:subfield>' +
+        '<marcx:subfield code="d">20201022</marcx:subfield>' +
+        '<marcx:subfield code="f">a</marcx:subfield>' +
+        '</marcx:datafield>' +
+        '<marcx:datafield ind1="0" ind2="0" tag="004">' +
+        '<marcx:subfield code="r">n</marcx:subfield>' +
+        '<marcx:subfield code="a">e</marcx:subfield>' +
+        '</marcx:datafield>' +
+        '<marcx:datafield ind1="0" ind2="0" tag="008">' +
+        '<marcx:subfield code="t">s</marcx:subfield>' +
+        '<marcx:subfield code="u">f</marcx:subfield>' +
+        '<marcx:subfield code="a">2020</marcx:subfield>' +
+        '<marcx:subfield code="b">dk</marcx:subfield>' +
+        '<marcx:subfield code="d">x</marcx:subfield>' +
+        '<marcx:subfield code="j">p</marcx:subfield>' +
+        '<marcx:subfield code="l">dan</marcx:subfield>' +
+        '<marcx:subfield code="v">0</marcx:subfield>' +
+        '</marcx:datafield>' +
+        '<marcx:datafield ind1="0" ind2="0" tag="009">' +
+        '<marcx:subfield code="a">a</marcx:subfield>' +
+        '<marcx:subfield code="g">xx</marcx:subfield>' +
+        '</marcx:datafield>' +
+        '<marcx:datafield ind1="0" ind2="0" tag="021">' +
+        '<marcx:subfield code="e">9788793871472</marcx:subfield>' +
+        '<marcx:subfield code="c">hf.</marcx:subfield>' +
+        '</marcx:datafield>' +
+        '<marcx:datafield ind1="0" ind2="0" tag="032">' +
+        '<marcx:subfield code="x">ACC202043</marcx:subfield>' +
+        '<marcx:subfield code="a">DBF202048</marcx:subfield>' +
+        '<marcx:subfield code="x">BKM202048</marcx:subfield>' +
+        '</marcx:datafield>' +
+        '<marcx:datafield ind1="0" ind2="0" tag="041">' +
+        '<marcx:subfield code="a">dan</marcx:subfield>' +
+        '<marcx:subfield code="c">spa</marcx:subfield>' +
+        '</marcx:datafield>' +
+        '<marcx:datafield ind1="0" ind2="0" tag="100">' +
+        '<marcx:subfield code="5">870979</marcx:subfield>' +
+        '<marcx:subfield code="6">68339480</marcx:subfield>' +
+        '<marcx:subfield code="a">García Lorca</marcx:subfield>' +
+        '<marcx:subfield code="h">Federico</marcx:subfield>' +
+        '<marcx:subfield code="4">aut</marcx:subfield>' +
+        '</marcx:datafield>' +
+        '<marcx:datafield ind1="0" ind2="0" tag="241">' +
+        '<marcx:subfield code="a">Romancero gitano</marcx:subfield>' +
+        // no subfield 241u
+        '</marcx:datafield>' +
+        '</marcx:record>' +
+        '</marcx:collection>';
+
+    actual = OaiFormatter.formatRecords( records, format, allowedSets );
+    testName = "Format single record to marcxchange + bkm not allowed set + hide subfield 241 *u";
     Assert.equalXml( testName, actual, expected );
 
 });

--- a/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
+++ b/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
@@ -238,7 +238,6 @@ UnitTest.addFixture( "OaiFormatter.formatRecords (format DC)", function() {
 
 } );
 
-
 UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, bkm as allowed set)", function() {
 
     var format = 'marcx'; //applies to all tests in this Fixture
@@ -687,7 +686,6 @@ UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, bkm as allowed s
 
 } );
 
-
 UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, bkm NOT allowed set)", function() {
 
     var format = 'marcx';
@@ -987,9 +985,141 @@ UnitTest.addFixture( "OaiFormatter.convertXmlRecordStringsToMarcObjects", functi
 
 } );
 
-
 UnitTest.addFixture( "OaiFormatter.getAllowedFormats", function() {
 
     Assert.equalValue( "get allowed formats", OaiFormatter.getAllowedFormats(), [ 'oai_dc', 'marcx' ] );
 
 } );
+
+// SAHU: starting with unit tests
+UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, nat as allowed set, excl. 241 *u)", function() {
+
+    var format = 'marcx'; // applies to all tests in this fixture
+    var allowedSets = [ "BKM", "NAT" ]; // applies to all tests in this fixture
+
+    var recordString =
+       '<marcx:record format="danMARC2" type="Bibliographic">' +
+           '<marcx:leader>00000name 22000000  4500</marcx:leader>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="001">' +
+               '<marcx:subfield code="a">38240803</marcx:subfield>' + 
+               '<marcx:subfield code="b">870970</marcx:subfield>' + 
+               '<marcx:subfield code="c">20210216122929</marcx:subfield>' + 
+               '<marcx:subfield code="d">20201022</marcx:subfield>' + 
+               '<marcx:subfield code="f">a</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="004">' +
+               '<marcx:subfield code="r">n</marcx:subfield>' + 
+               '<marcx:subfield code="a">e</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="008">' +
+               '<marcx:subfield code="t">s</marcx:subfield>' + 
+               '<marcx:subfield code="u">f</marcx:subfield>' + 
+               '<marcx:subfield code="a">2020</marcx:subfield>' + 
+               '<marcx:subfield code="b">dk</marcx:subfield>' + 
+               '<marcx:subfield code="d">x</marcx:subfield>' + 
+               '<marcx:subfield code="j">p</marcx:subfield>' + 
+               '<marcx:subfield code="l">dan</marcx:subfield>' + 
+               '<marcx:subfield code="v">0</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="009">' +
+               '<marcx:subfield code="a">a</marcx:subfield>' + 
+               '<marcx:subfield code="g">xx</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="021">' +
+               '<marcx:subfield code="e">9788793871472</marcx:subfield>' + 
+               '<marcx:subfield code="c">hf.</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="032">' +
+               '<marcx:subfield code="x">ACC202043</marcx:subfield>' + 
+               '<marcx:subfield code="a">DBF202048</marcx:subfield>' + 
+               '<marcx:subfield code="x">BKM202048</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="041">' +
+               '<marcx:subfield code="a">dan</marcx:subfield>' + 
+               '<marcx:subfield code="c">spa</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="100">' +
+               '<marcx:subfield code="5">870979</marcx:subfield>' + 
+               '<marcx:subfield code="6">68339480</marcx:subfield>' + 
+               '<marcx:subfield code="a">García Lorca</marcx:subfield>' + 
+               '<marcx:subfield code="h">Federico</marcx:subfield>' + 
+               '<marcx:subfield code="4">aut</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="241">' +
+               '<marcx:subfield code="a">Romancero gitano</marcx:subfield>' + 
+               '<marcx:subfield code="u">1928</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="245">' +
+               '<marcx:subfield code="a">Sigøjnerballader</marcx:subfield>' + 
+               '<marcx:subfield code="ø">Ved Juancío d\'Héroville</marcx:subfield>' +
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="250">' +
+               '<marcx:subfield code="a">1. udgave</marcx:subfield>' + 
+               '<marcx:subfield code="b">÷</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="260">' +
+               '<marcx:subfield code="a">[Kbh.]</marcx:subfield>' + 
+               '<marcx:subfield code="b">Det Poetiske Bureau</marcx:subfield>' + 
+               '<marcx:subfield code="c">2020</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="300">' +
+               '<marcx:subfield code="a">89 sider</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="440">' +
+               '<marcx:subfield code="0"/>' +
+               '<marcx:subfield code="a">Bureauets lommebibliotek</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="504">' +
+               '<marcx:subfield code="a">Dramatiske digte fulde af historier og smerte. For læsere af modernistiske, oversatte digte</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="521">' +
+               '<marcx:subfield code="b">1. oplag</marcx:subfield>' + 
+               '<marcx:subfield code="c">2020</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="530">' +
+               '<marcx:subfield code="i">Indhold</marcx:subfield>' + 
+               '<marcx:subfield code="t">Romancen om månen, månen</marcx:subfield>' + 
+               '<marcx:subfield code="t">Preciosa og vinden</marcx:subfield>' + 
+               '<marcx:subfield code="t">Fejde</marcx:subfield>' + 
+               '<marcx:subfield code="t">Søvngængerromance</marcx:subfield>' + 
+               '<marcx:subfield code="t">Sigøjnernonnen</marcx:subfield>' + 
+               '<marcx:subfield code="t">Den ¤utro hustru</marcx:subfield>' + 
+               '<marcx:subfield code="t">Romancen om den sorte smerte</marcx:subfield>' + 
+               '<marcx:subfield code="t">Skt. Mikkel (Granada)</marcx:subfield>' + 
+               '<marcx:subfield code="t">Skt. Rafael (Cordoba)</marcx:subfield>' + 
+               '<marcx:subfield code="t">Skt. Gabriel (Sevilla)</marcx:subfield>' + 
+               '<marcx:subfield code="t">Lille Antonio Camborios tilfangetagelse på vejen til Sevilla</marcx:subfield>' + 
+               '<marcx:subfield code="t">Lille Antonio Camborios død</marcx:subfield>' + 
+               '<marcx:subfield code="t">Død af kærlighed</marcx:subfield>' + 
+               '<marcx:subfield code="t">Den ¤mærkede mand</marcx:subfield>' + 
+               '<marcx:subfield code="t">Romancen om den spanske civilgarde</marcx:subfield>' + 
+               '<marcx:subfield code="t">Skt. Eulalias martyrium</marcx:subfield>' + 
+               '<marcx:subfield code="t">Vittighed om don Pedro til hest</marcx:subfield>' + 
+               '<marcx:subfield code="t">Thamar og Amnon</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="652">' +
+               '<marcx:subfield code="n">82.7</marcx:subfield>' + 
+               '<marcx:subfield code="z">21</marcx:subfield>' + 
+            '</marcx:datafield>' +
+           '<marcx:datafield ind1="0" ind2="0" tag="652">' +
+               '<marcx:subfield code="o">sk</marcx:subfield>' + 
+            '</marcx:datafield>' +
+        '</marcx:record>';
+
+
+    var records = [
+        {
+            content: recordString,
+            children: []
+        }
+    ];
+
+    // TODO Find out what's expected
+    var expected;
+
+});
+
+UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, bkm as allowed set, incl. 241 *u)", function() {
+
+
+});

--- a/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
+++ b/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
@@ -991,8 +991,8 @@ UnitTest.addFixture( "OaiFormatter.getAllowedFormats", function() {
 
 } );
 
-
-UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, subfield 241u)", function() {
+// SAHU Unit test to ensure show/hide subfield 241u
+UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, nat and/or bkm, subfield 241u)", function() {
 
     var format = 'marcx'; // applies to all tests in this fixture
 

--- a/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
+++ b/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
@@ -991,7 +991,7 @@ UnitTest.addFixture( "OaiFormatter.getAllowedFormats", function() {
 
 } );
 
-// SAHU Unit test to ensure show/hide subfield 241u
+// Search US#OAI-9
 UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, nat and/or bkm, subfield 241u)", function() {
 
     var format = 'marcx'; // applies to all tests in this fixture

--- a/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
+++ b/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
@@ -992,7 +992,7 @@ UnitTest.addFixture( "OaiFormatter.getAllowedFormats", function() {
 } );
 
 // SAHU: starting with unit tests
-UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, nat as allowed set, excl. 241 *u)", function() {
+UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, nat + bkm, subfield 241 *u)", function() {
 
     var format = 'marcx'; // applies to all tests in this fixture
     var allowedSets = [ "BKM", "NAT" ]; // applies to all tests in this fixture
@@ -1047,63 +1047,8 @@ UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, nat as allowed s
             '</marcx:datafield>' +
            '<marcx:datafield ind1="0" ind2="0" tag="241">' +
                '<marcx:subfield code="a">Romancero gitano</marcx:subfield>' + 
-               '<marcx:subfield code="u">1928</marcx:subfield>' + 
-            '</marcx:datafield>' +
-           '<marcx:datafield ind1="0" ind2="0" tag="245">' +
-               '<marcx:subfield code="a">Sigøjnerballader</marcx:subfield>' + 
-               '<marcx:subfield code="ø">Ved Juancío d\'Héroville</marcx:subfield>' +
-            '</marcx:datafield>' +
-           '<marcx:datafield ind1="0" ind2="0" tag="250">' +
-               '<marcx:subfield code="a">1. udgave</marcx:subfield>' + 
-               '<marcx:subfield code="b">÷</marcx:subfield>' + 
-            '</marcx:datafield>' +
-           '<marcx:datafield ind1="0" ind2="0" tag="260">' +
-               '<marcx:subfield code="a">[Kbh.]</marcx:subfield>' + 
-               '<marcx:subfield code="b">Det Poetiske Bureau</marcx:subfield>' + 
-               '<marcx:subfield code="c">2020</marcx:subfield>' + 
-            '</marcx:datafield>' +
-           '<marcx:datafield ind1="0" ind2="0" tag="300">' +
-               '<marcx:subfield code="a">89 sider</marcx:subfield>' + 
-            '</marcx:datafield>' +
-           '<marcx:datafield ind1="0" ind2="0" tag="440">' +
-               '<marcx:subfield code="0"/>' +
-               '<marcx:subfield code="a">Bureauets lommebibliotek</marcx:subfield>' + 
-            '</marcx:datafield>' +
-           '<marcx:datafield ind1="0" ind2="0" tag="504">' +
-               '<marcx:subfield code="a">Dramatiske digte fulde af historier og smerte. For læsere af modernistiske, oversatte digte</marcx:subfield>' + 
-            '</marcx:datafield>' +
-           '<marcx:datafield ind1="0" ind2="0" tag="521">' +
-               '<marcx:subfield code="b">1. oplag</marcx:subfield>' + 
-               '<marcx:subfield code="c">2020</marcx:subfield>' + 
-            '</marcx:datafield>' +
-           '<marcx:datafield ind1="0" ind2="0" tag="530">' +
-               '<marcx:subfield code="i">Indhold</marcx:subfield>' + 
-               '<marcx:subfield code="t">Romancen om månen, månen</marcx:subfield>' + 
-               '<marcx:subfield code="t">Preciosa og vinden</marcx:subfield>' + 
-               '<marcx:subfield code="t">Fejde</marcx:subfield>' + 
-               '<marcx:subfield code="t">Søvngængerromance</marcx:subfield>' + 
-               '<marcx:subfield code="t">Sigøjnernonnen</marcx:subfield>' + 
-               '<marcx:subfield code="t">Den ¤utro hustru</marcx:subfield>' + 
-               '<marcx:subfield code="t">Romancen om den sorte smerte</marcx:subfield>' + 
-               '<marcx:subfield code="t">Skt. Mikkel (Granada)</marcx:subfield>' + 
-               '<marcx:subfield code="t">Skt. Rafael (Cordoba)</marcx:subfield>' + 
-               '<marcx:subfield code="t">Skt. Gabriel (Sevilla)</marcx:subfield>' + 
-               '<marcx:subfield code="t">Lille Antonio Camborios tilfangetagelse på vejen til Sevilla</marcx:subfield>' + 
-               '<marcx:subfield code="t">Lille Antonio Camborios død</marcx:subfield>' + 
-               '<marcx:subfield code="t">Død af kærlighed</marcx:subfield>' + 
-               '<marcx:subfield code="t">Den ¤mærkede mand</marcx:subfield>' + 
-               '<marcx:subfield code="t">Romancen om den spanske civilgarde</marcx:subfield>' + 
-               '<marcx:subfield code="t">Skt. Eulalias martyrium</marcx:subfield>' + 
-               '<marcx:subfield code="t">Vittighed om don Pedro til hest</marcx:subfield>' + 
-               '<marcx:subfield code="t">Thamar og Amnon</marcx:subfield>' + 
-            '</marcx:datafield>' +
-           '<marcx:datafield ind1="0" ind2="0" tag="652">' +
-               '<marcx:subfield code="n">82.7</marcx:subfield>' + 
-               '<marcx:subfield code="z">21</marcx:subfield>' + 
-            '</marcx:datafield>' +
-           '<marcx:datafield ind1="0" ind2="0" tag="652">' +
-               '<marcx:subfield code="o">sk</marcx:subfield>' + 
-            '</marcx:datafield>' +
+               '<marcx:subfield code="u">1928</marcx:subfield>' +
+        '</marcx:datafield>' +
         '</marcx:record>';
 
 
@@ -1115,11 +1060,72 @@ UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, nat as allowed s
     ];
 
     // TODO Find out what's expected
-    var expected;
+    var expected =
+        '<marcx:collection xmlns:marcx="info:lc/xmlns/marcxchange-v1">' +
+            '<marcx:record format="danMARC2" type="Bibliographic">' +
+                '<marcx:leader>00000name 22000000  4500</marcx:leader>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="001">' +
+                    '<marcx:subfield code="a">38240803</marcx:subfield>' +
+                    '<marcx:subfield code="b">870970</marcx:subfield>' +
+                    '<marcx:subfield code="c">20210216122929</marcx:subfield>' +
+                    '<marcx:subfield code="d">20201022</marcx:subfield>' +
+                    '<marcx:subfield code="f">a</marcx:subfield>' +
+                '</marcx:datafield>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="004">' +
+                    '<marcx:subfield code="r">n</marcx:subfield>' +
+                    '<marcx:subfield code="a">e</marcx:subfield>' +
+                '</marcx:datafield>' +
+                    '<marcx:datafield ind1="0" ind2="0" tag="008">' +
+                    '<marcx:subfield code="t">s</marcx:subfield>' +
+                    '<marcx:subfield code="u">f</marcx:subfield>' +
+                    '<marcx:subfield code="a">2020</marcx:subfield>' +
+                    '<marcx:subfield code="b">dk</marcx:subfield>' +
+                    '<marcx:subfield code="d">x</marcx:subfield>' +
+                    '<marcx:subfield code="j">p</marcx:subfield>' +
+                    '<marcx:subfield code="l">dan</marcx:subfield>' +
+                    '<marcx:subfield code="v">0</marcx:subfield>' +
+                '</marcx:datafield>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="009">' +
+                    '<marcx:subfield code="a">a</marcx:subfield>' +
+                    '<marcx:subfield code="g">xx</marcx:subfield>' +
+                '</marcx:datafield>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="021">' +
+                    '<marcx:subfield code="e">9788793871472</marcx:subfield>' +
+                    '<marcx:subfield code="c">hf.</marcx:subfield>' +
+                '</marcx:datafield>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="032">' +
+                    '<marcx:subfield code="x">ACC202043</marcx:subfield>' +
+                    '<marcx:subfield code="a">DBF202048</marcx:subfield>' +
+                    '<marcx:subfield code="x">BKM202048</marcx:subfield>' +
+                '</marcx:datafield>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="041">' +
+                    '<marcx:subfield code="a">dan</marcx:subfield>' +
+                    '<marcx:subfield code="c">spa</marcx:subfield>' +
+                '</marcx:datafield>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="100">' +
+                    '<marcx:subfield code="5">870979</marcx:subfield>' +
+                    '<marcx:subfield code="6">68339480</marcx:subfield>' +
+                    '<marcx:subfield code="a">García Lorca</marcx:subfield>' +
+                    '<marcx:subfield code="h">Federico</marcx:subfield>' +
+                    '<marcx:subfield code="4">aut</marcx:subfield>' +
+                '</marcx:datafield>' +
+                '<marcx:datafield ind1="0" ind2="0" tag="241">' +
+                    '<marcx:subfield code="a">Romancero gitano</marcx:subfield>' +
+                    '<marcx:subfield code="u">1928</marcx:subfield>' +
+                '</marcx:datafield>' +
+            '</marcx:record>' +
+        '</marcx:collection>';
+
+    var actual = OaiFormatter.formatRecords( records, format, allowedSets );
+
+    var testName = "Format single record to marcxchange + bkm allowed set + show subfield 241 *u";
+
+    Assert.equalXml( testName, actual, expected );
+
 
 });
 
-UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, bkm as allowed set, incl. 241 *u)", function() {
-
-
-});
+// UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, bkm as allowed set, incl. 241 *u)", function() {
+//
+//
+// });

--- a/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
+++ b/formatter-js/src/main/resources/javascript/OaiFormatter.test.js
@@ -991,14 +991,14 @@ UnitTest.addFixture( "OaiFormatter.getAllowedFormats", function() {
 
 } );
 
-// SAHU: starting with unit tests
-UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, nat + bkm, subfield 241 *u)", function() {
+// TODO: starting with unit tests
+UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, subfield 241u)", function() {
 
     var format = 'marcx'; // applies to all tests in this fixture
-    var allowedSets = [ "BKM", "NAT" ]; // applies to all tests in this fixture
+    var allowedSets = [ "BKM", "NAT" ];
 
     var recordString =
-       '<marcx:record format="danMARC2" type="Bibliographic">' +
+       '<marcx:record format="danMARC2" type="Bibliographic" xmlns:marcx="info:lc/xmlns/marcxchange-v1">' +
            '<marcx:leader>00000name 22000000  4500</marcx:leader>' +
            '<marcx:datafield ind1="0" ind2="0" tag="001">' +
                '<marcx:subfield code="a">38240803</marcx:subfield>' + 
@@ -1059,7 +1059,7 @@ UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, nat + bkm, subfi
         }
     ];
 
-    // TODO Find out what's expected
+    // include 241u
     var expected =
         '<marcx:collection xmlns:marcx="info:lc/xmlns/marcxchange-v1">' +
             '<marcx:record format="danMARC2" type="Bibliographic">' +
@@ -1122,10 +1122,4 @@ UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, nat + bkm, subfi
 
     Assert.equalXml( testName, actual, expected );
 
-
 });
-
-// UnitTest.addFixture( "OaiFormatter.formatRecords (format marcx, bkm as allowed set, incl. 241 *u)", function() {
-//
-//
-// });

--- a/formatter-js/src/main/resources/javascript/OaiFormatter.use.js
+++ b/formatter-js/src/main/resources/javascript/OaiFormatter.use.js
@@ -87,6 +87,7 @@ var OaiFormatter = function() {
                     marcRecord = MarcXchangeToOaiMarcX.removeField665( marcRecord ); //Search US#2373. Remove this call when 665 is official field.
                     if ( !bkmRecordAllowed ) {
                         marcRecord = MarcXchangeToOaiMarcX.removeBkmFields( marcRecord );
+                        marcRecord = MarcXchangeToOaiMarcX.removeSubfield241u( marcRecord ); // US#OAI-9
                     }
                     marcRecord = MarcXchangeToOaiMarcX.removeLocalSubfieldsIfAny( marcRecord );
                     var marcXDoc = MarcXchangeToOaiMarcX.createMarcXmlWithRightRecordType( marcRecord );


### PR DESCRIPTION
Added function for removing subfield 241u, when BKM set is not allowed. Added unit test to ensure wanted functionality of method.