### PR TITLE
Increase migrate db pool size to 2

### DIFF
--- a/setmatcher/src/main/docker/app.json
+++ b/setmatcher/src/main/docker/app.json
@@ -4,7 +4,7 @@
         "jdbc/rawrepo-oai-migrate": {
             "xa": false,
             "url": "${RAWREPO_OAI_POSTGRES_URL}",
-            "maxSize": "1",
+            "maxSize": "2",
             "steadySize": "0"
         },
         "jdbc/rawrepo-oai": {


### PR DESCRIPTION
I seems like flyway now requires two connections for a migration.